### PR TITLE
Add docker compose setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,14 @@
 .idea
 *.iml
 
+# OSX
+.DS_Store
+
 # NodeJS
 node_modules
 dist
 package-lock.json
+yarn.lock
 
 # Java
 .gradle

--- a/README.md
+++ b/README.md
@@ -115,13 +115,48 @@ This is also the perfect place for sharing your feedback with us, learning more 
 
 ## Running the examples
 
-Some examples are just illustrations of code, but many are runnable. Their READMEs explain
-how to get them running. Here are the general steps:
+### Using docker compose
 
-### (1) Starting the Restate Server
+Easiset way to bring up and test an endpoint is using the docker compose setup. From the root of the repo, run
 
-To run an example locally, you need a running Restate Server instance.
-Some examples can be run with Docker Compose. Those already bring their own Restate server instance.
+```
+docker compose up -d
+```
+This will bring up 
+- restate server
+- [typescript example-0](typescript/basics/src/0_durable_execution.ts)
+- register the endpoint /service with restate 
+
+You can test the endpoint by calling 
+
+```
+curl --request POST \
+  --url http://127.0.0.1:8080/SubscriptionService/add \
+  --header 'Accept: application/json' \
+  --header 'Content-Type: application/json' \
+  --header 'idempotency-key: some-key-for-idempotentcy' \
+  --data '{
+    "userId": "Sam Beckett",
+    "creditCard": "1234-5678-9012-3456",
+    "subscriptions" : ["Netflix", "Disney+", "HBO Max"]
+}'
+
+```
+
+You can check that it succeeded by visiting http://localhost:9070/ui/invocations?service=SubscriptionService
+
+Now you can register additional endpoints onto restate. 
+
+Some examples are just illustrations of code, but many are runnable. Their READMEs explain how to get them running. Here are the general steps:
+
+### 
+
+### (1) Optional - Starting the Restate Server
+
+To run an example locally, you need a running Restate Server instance. 
+
+You can skip this step if you have the docker compose setup, shown above, having started the restate server.
+
 
 To install the Restate Server and CLI, have a look at the [installation instructions in the documentation](https://docs.restate.dev/develop/local_dev#running-restate-server--cli-locally).
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,42 @@
+services:
+  endpoint:
+    image: node:20.15
+    working_dir: /endpoint
+    ports:
+      - "9080:9080"
+    command:
+      - /bin/bash
+      - -c
+      - |
+        if [ ! -d "examples" ]; then
+          git clone --depth=1 https://github.com/restatedev/examples.git
+        fi
+        cd examples/typescript/basics
+        npm install
+        npm run example-0 # or 2, 3
+    healthcheck:
+      test: curl --http2-prior-knowledge http://localhost:9080 || exit 1
+      interval: 5s
+      retries: 10
+      start_period: 5s
+      timeout: 10s
+  restate:
+    image: docker.io/restatedev/restate:latest
+    pull_policy: always
+    ports:
+      - 8080:8080
+      - 9070:9070
+      - 9071:9071
+  register_endpoint:
+    image: docker.io/curlimages/curl:8.8.0
+    depends_on:
+      endpoint:
+        condition: service_healthy
+      restate:
+        condition: service_started
+    command:
+      - /bin/sh
+      - -c
+      - |
+        curl --retry 10 http://restate:9070/deployments -H 'content-type: application/json' -d '{"uri": "http://endpoint:9080"}'
+        echo "Endpoint successfully registered"


### PR DESCRIPTION
This PR adds:

- A docker compose setup to start everything up and register a sample endpoint 
- Update the readme to reflect the changes